### PR TITLE
Pass on severity when calling old style (info, debug, warn, etc) functions

### DIFF
--- a/client.js
+++ b/client.js
@@ -213,6 +213,7 @@ HekaClient.prototype.timer = function(fn, name, opts) {
 HekaClient.prototype._oldstyle = function(severity, msg, opts) {
     if (opts === undefined) opts = {};
     if (opts.fields === undefined) opts.fields = {};
+    opts.severity = opts.severity || severity;
     opts.payload = String(msg);
     this.heka('oldstyle', opts);
 }
@@ -227,6 +228,10 @@ HekaClient.prototype.info = function(msg, opts) {
 
 HekaClient.prototype.warn = function(msg, opts) {
     this._oldstyle(SEVERITY.WARNING, msg, opts);
+}
+
+HekaClient.prototype.notice = function(msg, opts) {
+    this._oldstyle(SEVERITY.NOTICE, msg, opts);
 }
 
 HekaClient.prototype.error = function(msg, opts) {

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -304,20 +304,23 @@ describe('client', function() {
     });
 
     it("provides simple oldstyle logging methods", function() {
-        var msg_pairs = [[client.debug, "debug_msg"],
-        [client.info, "info_msg"],
-        [client.warn, "warn_msg"],
-        [client.error, "err_msg"],
-        [client.exception, "exc_msg"],
-        [client.critical, "crit_msg"]]
+        var msg_pairs = [[client.debug, "debug_msg", heka.SEVERITY.DEBUG],
+        [client.info, "info_msg", heka.SEVERITY.INFORMATIONAL],
+        [client.warn, "warn_msg", heka.SEVERITY.WARNING],
+        [client.notice, "not_msg", heka.SEVERITY.NOTICE],
+        [client.error, "err_msg", heka.SEVERITY.ERROR],
+        [client.exception, "exc_msg", heka.SEVERITY.ALERT],
+        [client.critical, "crit_msg", heka.SEVERITY.CRITICAL]]
 
         _.each(msg_pairs, function(elem) {
             var method = elem[0];
             var data = elem[1];
+            var severity = elem[2];
             method.call(client, data)
             expect(_.last(client.sender.msgs).payload).toEqual(data);
+            expect(_.last(client.sender.msgs).severity).toEqual(severity);
         });
-        expect(client.sender.msgs.length).toEqual(6);
+        expect(client.sender.msgs.length).toEqual(msg_pairs.length);
     });
 
     it('honors disabledTimers', function() {


### PR DESCRIPTION
- Add a HekaClient.prototype.notice
