### PR TITLE
Added `createClient()`, which takes a javascript option argument.

### DIFF
--- a/client.js
+++ b/client.js
@@ -264,5 +264,6 @@ exports.BoxedFloat = BoxedFloat;
 exports.DateToNano = DateToNano;
 exports.HekaClient = HekaClient;
 exports.clientFromJsonConfig = config.clientFromJsonConfig;
+exports.createClient = config.createClient;
 exports.SEVERITY = SEVERITY;
 exports.streams = streams;

--- a/config.js
+++ b/config.js
@@ -41,8 +41,7 @@ var streamFromConfig = function(config) {
     return stream;
 };
 
-var clientFromJsonConfig = function(config, client) {
-    config = JSON.parse(config);
+var createClient = function(config, client) {
     var streamConfig = getattr(config, 'stream');
     var stream = streamFromConfig(streamConfig);
     var logger = getattr(config, 'logger', '');
@@ -77,5 +76,11 @@ var clientFromJsonConfig = function(config, client) {
     return client;
 };
 
+var clientFromJsonConfig = function(config, client) {
+    config = JSON.parse(config);
+    return createClient(config, client);
+};
+
 exports.resolveName = resolveName;
 exports.clientFromJsonConfig = clientFromJsonConfig;
+exports.createClient = createClient;

--- a/tests/config.spec.js
+++ b/tests/config.spec.js
@@ -87,6 +87,32 @@ describe('config', function() {
         expect(msg.severity).toEqual(config.severity);
     });
 
+    it('sets up a client from an object as well as a string', function() {
+        var config = {
+            'stream': {'factory': makeMockStreamString},
+            'logger': 'test',
+            'severity': 5
+        };
+        var client = configModule.createClient(config);
+        expect(client.logger).toEqual(config.logger);
+        expect(client.severity).toEqual(config.severity);
+
+        var msgOpts = {'payload': 'whadidyusay?'};
+        var type = 'test-type'
+
+        client.heka(type, msgOpts);
+
+        expect(client.stream.msgs.length).toEqual(1);
+
+        var wire_buff = client.stream.msgs.pop();
+        var decoded = m_helpers.decode_message(wire_buff);
+        var header = decoded['header'];
+        var msg = decoded['message'];
+        expect(msg.type).toEqual(type);
+        expect(msg.payload).toEqual(msgOpts.payload);
+        expect(msg.severity).toEqual(config.severity);
+    });
+
     it('sets up filters', function() {
         var filterConfig = {'payload': 'nay!'};
         var config = {


### PR DESCRIPTION
Implemented `clientFromJsonConfig()` by parsing the input string &
calling `createClient`.  Added a test for a client created this way.
