### PR TITLE
npm adds ./node_modules/.bin to the $PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
         "horaa": ">=0.1.1alpha"
     },
     "scripts": {
-        "test": "node_modules/jasmine-node/bin/jasmine-node --captureExceptions tests"
+        "test": "jasmine-node --captureExceptions tests"
     }
 }


### PR DESCRIPTION
Therefore, we can use it for jasmine-node since that packages adds it as a bin file.
